### PR TITLE
Fix mailgun_domain_stats_* metrics always reporting 0

### DIFF
--- a/mailgun_client.go
+++ b/mailgun_client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"time"
 
 	"github.com/mailgun/mailgun-go/v5"
 	"github.com/mailgun/mailgun-go/v5/mtypes"
@@ -44,7 +45,10 @@ func (w *mailgunClientWrapper) GetDomains(ctx context.Context) ([]mtypes.Domain,
 
 func (w *mailgunClientWrapper) GetMetrics(ctx context.Context, domain string) (*mtypes.Metrics, error) {
 	opts := mailgun.MetricsOptions{
-		Duration: "4h",
+		End:               mtypes.RFC2822Time(time.Now().UTC()),
+		Duration:          "4h",
+		Resolution:        mtypes.ResolutionHour,
+		IncludeAggregates: true,
 		Filter: mtypes.MetricsFilterPredicateGroup{
 			BoolGroupAnd: []mtypes.MetricsFilterPredicate{{
 				Attribute:     "domain",
@@ -79,134 +83,11 @@ func (w *mailgunClientWrapper) GetMetrics(ctx context.Context, domain string) (*
 		return nil, err
 	}
 
-	aggregatedMetrics := &mtypes.Metrics{}
-
 	var resp mtypes.MetricsResponse
-	for iter.Next(ctx, &resp) {
-		if resp.Aggregates.Metrics.AcceptedIncomingCount != nil {
-			aggregatedMetrics = &resp.Aggregates.Metrics
-			break
-		}
-		for _, item := range resp.Items {
-			addMetrics(aggregatedMetrics, &item.Metrics)
-		}
-	}
-
+	iter.Next(ctx, &resp)
 	if iter.Err() != nil {
 		return nil, iter.Err()
 	}
 
-	return aggregatedMetrics, nil
-}
-
-// addMetrics adds the values from src to dst
-func addMetrics(dst, src *mtypes.Metrics) {
-	if src.AcceptedIncomingCount != nil {
-		if dst.AcceptedIncomingCount == nil {
-			dst.AcceptedIncomingCount = new(uint64)
-		}
-		*dst.AcceptedIncomingCount += *src.AcceptedIncomingCount
-	}
-	if src.AcceptedOutgoingCount != nil {
-		if dst.AcceptedOutgoingCount == nil {
-			dst.AcceptedOutgoingCount = new(uint64)
-		}
-		*dst.AcceptedOutgoingCount += *src.AcceptedOutgoingCount
-	}
-	if src.ClickedCount != nil {
-		if dst.ClickedCount == nil {
-			dst.ClickedCount = new(uint64)
-		}
-		*dst.ClickedCount += *src.ClickedCount
-	}
-	if src.ComplainedCount != nil {
-		if dst.ComplainedCount == nil {
-			dst.ComplainedCount = new(uint64)
-		}
-		*dst.ComplainedCount += *src.ComplainedCount
-	}
-	if src.DeliveredHTTPCount != nil {
-		if dst.DeliveredHTTPCount == nil {
-			dst.DeliveredHTTPCount = new(uint64)
-		}
-		*dst.DeliveredHTTPCount += *src.DeliveredHTTPCount
-	}
-	if src.DeliveredSMTPCount != nil {
-		if dst.DeliveredSMTPCount == nil {
-			dst.DeliveredSMTPCount = new(uint64)
-		}
-		*dst.DeliveredSMTPCount += *src.DeliveredSMTPCount
-	}
-	if src.PermanentFailedCount != nil {
-		if dst.PermanentFailedCount == nil {
-			dst.PermanentFailedCount = new(uint64)
-		}
-		*dst.PermanentFailedCount += *src.PermanentFailedCount
-	}
-	if src.TemporaryFailedCount != nil {
-		if dst.TemporaryFailedCount == nil {
-			dst.TemporaryFailedCount = new(uint64)
-		}
-		*dst.TemporaryFailedCount += *src.TemporaryFailedCount
-	}
-	if src.OpenedCount != nil {
-		if dst.OpenedCount == nil {
-			dst.OpenedCount = new(uint64)
-		}
-		*dst.OpenedCount += *src.OpenedCount
-	}
-	if src.StoredCount != nil {
-		if dst.StoredCount == nil {
-			dst.StoredCount = new(uint64)
-		}
-		*dst.StoredCount += *src.StoredCount
-	}
-	if src.UnsubscribedCount != nil {
-		if dst.UnsubscribedCount == nil {
-			dst.UnsubscribedCount = new(uint64)
-		}
-		*dst.UnsubscribedCount += *src.UnsubscribedCount
-	}
-	if src.HardBouncesCount != nil {
-		if dst.HardBouncesCount == nil {
-			dst.HardBouncesCount = new(uint64)
-		}
-		*dst.HardBouncesCount += *src.HardBouncesCount
-	}
-	if src.SoftBouncesCount != nil {
-		if dst.SoftBouncesCount == nil {
-			dst.SoftBouncesCount = new(uint64)
-		}
-		*dst.SoftBouncesCount += *src.SoftBouncesCount
-	}
-	if src.DelayedBounceCount != nil {
-		if dst.DelayedBounceCount == nil {
-			dst.DelayedBounceCount = new(uint64)
-		}
-		*dst.DelayedBounceCount += *src.DelayedBounceCount
-	}
-	if src.SuppressedBouncesCount != nil {
-		if dst.SuppressedBouncesCount == nil {
-			dst.SuppressedBouncesCount = new(uint64)
-		}
-		*dst.SuppressedBouncesCount += *src.SuppressedBouncesCount
-	}
-	if src.SuppressedComplaintsCount != nil {
-		if dst.SuppressedComplaintsCount == nil {
-			dst.SuppressedComplaintsCount = new(uint64)
-		}
-		*dst.SuppressedComplaintsCount += *src.SuppressedComplaintsCount
-	}
-	if src.SuppressedUnsubscribedCount != nil {
-		if dst.SuppressedUnsubscribedCount == nil {
-			dst.SuppressedUnsubscribedCount = new(uint64)
-		}
-		*dst.SuppressedUnsubscribedCount += *src.SuppressedUnsubscribedCount
-	}
-	if src.TemporaryFailedESPBlockCount != nil {
-		if dst.TemporaryFailedESPBlockCount == nil {
-			dst.TemporaryFailedESPBlockCount = new(uint64)
-		}
-		*dst.TemporaryFailedESPBlockCount += *src.TemporaryFailedESPBlockCount
-	}
+	return &resp.Aggregates.Metrics, nil
 }

--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 		if metrics.AcceptedIncomingCount == nil && metrics.AcceptedOutgoingCount == nil {
 			log.Warn().Str("domain", domain).
-				Msg("Metrics API returned no data; check that your Mailgun plan includes the analytics API")
+				Msg("Metrics API returned no data; check that your Mailgun plan includes the analytics API, or verify that there was mail activity in the last 4h.")
 		}
 
 		ch <- prometheus.MustNewConstMetric(e.accepted, prometheus.GaugeValue, getVal(metrics.AcceptedIncomingCount), domain, "incoming")


### PR DESCRIPTION
This is to address https://github.com/missionlane/prometheus-mailgun-exporter/issues/125

- Set explicit end date and hourly resolution on the analytics request so Mailgun returns a real 4h window instead of an empty range.
- Read Mailgun's server-side aggregate totals directly instead of summing per-period buckets ourselves.
- Reword the no-data warning so it covers quiet domains as well.                                     
  
  See linked issue for full debugging context.

## Test plan
- [ ] `make docker` succeeds
- [ ] Run against a real account; `/metrics` shows non-zero `mailgun_domain_stats_*` for domains with recent activity
- [ ] Cross-check at least one busy domain against `/v3/<domain>/stats/total`
- [ ] Quiet/sandbox domains report zeros without false-positive warnings firing every scrape